### PR TITLE
Register capsule even if the package is disabled

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -17,6 +17,9 @@ class ServiceProvider extends TwillPackageServiceProvider
 
     public function boot(): void
     {
+        $this->registerThisCapsule();
+
+        
         if (!$this->registerConfig()) {
             return;
         }
@@ -24,8 +27,6 @@ class ServiceProvider extends TwillPackageServiceProvider
         $this->registerViews();
 
         $this->configureMiddeleware();
-
-        $this->registerThisCapsule();
 
         parent::boot();
     }


### PR DESCRIPTION
When adding `twillFirewall` to `twill.permissions.modules` with the `permissions-management` feature enabled in Twill 3 and `'level' => 'roleGroupItem',`, it breaks when `TWILL_FIREWALL_ENABLED` is set to `false`.

This is maybe not the right fix as Twill should not break when a module specified in `twill.permissions.modules` is not found. cc @ifox 

To reproduce:

```php
'enabled' => [
    'permissions-management' => true,
],
'permissions' => [
    'level' => 'roleGroupItem',
    'modules' => [
        'twillFirewall',
    ],
],
```

Then go to your CMS user profile.